### PR TITLE
#16 добавление api для чтения локаций и кампаний

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -189,6 +189,41 @@ export const logout = () =>
 		return res;
 	});
 
+export interface IApiLocation {
+	readonly id: UUID;
+	readonly name: string;
+	readonly address: string | null;
+	readonly description: string | null;
+}
+
+export const readLocations = () => ajax<IApiLocation[]>("/api/locations");
+
+export const readLocationById = (locId: UUID) => ajax<IApiLocation>(`/api/locations/${locId}`);
+
+export const addLocation = (name: string, address?: string | null, description?: string | null) =>
+	ajax<UUID>(
+		"/api/locations",
+		prepareAjax({name, address, description}, POST),
+	);
+
+export interface IApiCompany {
+	readonly id: UUID;
+	readonly master: UUID;
+	readonly name: string;
+	readonly system: string;
+	readonly description: string | null;
+}
+
+export const readMyCompanies = () => ajax<IApiCompany[]>("/api/companies/my");
+
+export const readCompanyById = (compId: UUID) => ajax<IApiCompany>(`/api/companies/${compId}`);
+
+export const addCompany = (name: string, system: string, description?: string | null) =>
+	ajax<UUID>(
+		"/api/companies",
+		prepareAjax({name, system, description}, POST),
+	);
+
 export interface IApiEvent {
 	readonly id: UUID;
 	readonly company: string;

--- a/openapi.json
+++ b/openapi.json
@@ -342,6 +342,24 @@
 			}
 		},
 		"/api/locations": {
+			"get": {
+				"tags": [
+					"locations"
+				],
+				"summary": "Получение списка локаций",
+				"responses": {
+					"200": {
+						"description": "Результат выполнения запроса",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppResponseWithLocationsList"
+								}
+							}
+						}
+					}
+				}
+			},
 			"post": {
 				"tags": [
 					"locations"
@@ -376,6 +394,38 @@
 				]
 			}
 		},
+		"/api/locations/{id}": {
+			"get": {
+				"tags": [
+					"locations"
+				],
+				"summary": "Получение локации по идентификатору",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"description": "Идентификатор локации",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Результат выполнения запроса",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppResponseWithLocation"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/api/companies": {
 			"post": {
 				"tags": [
@@ -399,6 +449,63 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/AppResponseWithUuid"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"cookieAuth": []
+					}
+				]
+			}
+		},
+		"/api/companies/{id}": {
+			"get": {
+				"tags": [
+					"companies"
+				],
+				"summary": "Получение кампании по идентификатору",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"description": "Идентификатор кампании",
+						"required": true,
+						"schema": {
+							"type": "string",
+							"format": "uuid"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Результат выполнения запроса",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppResponseWithCompany"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/companies/my": {
+			"get": {
+				"tags": [
+					"companies"
+				],
+				"summary": "Получение списка кампаний которые ведёт пользователь",
+				"responses": {
+					"200": {
+						"description": "Результат выполнения запроса",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppResponseWithCompanyList"
 								}
 							}
 						}
@@ -589,6 +696,31 @@
 					}
 				}
 			},
+			"Location": {
+				"type": "object",
+				"description": "Место проведения игр",
+				"properties": {
+					"id": {
+						"type": "string",
+						"format": "uuid",
+						"description": "Идентификатор локации"
+					},
+					"name": {
+						"type": "string",
+						"description": "Название локации"
+					},
+					"address": {
+						"type": "string",
+						"nullable": true,
+						"description": "Адрес локации"
+					},
+					"description": {
+						"type": "string",
+						"nullable": true,
+						"description": "Описание локации"
+					}
+				}
+			},
 			"NewLocationDto": {
 				"type": "object",
 				"description": "Данные для создания локации",
@@ -620,6 +752,35 @@
 					"system"
 				],
 				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Название кампании"
+					},
+					"system": {
+						"type": "string",
+						"description": "Система правил"
+					},
+					"description": {
+						"type": "string",
+						"nullable": true,
+						"description": "Описание локации"
+					}
+				}
+			},
+			"Company": {
+				"type": "object",
+				"description": "Описание кампании",
+				"properties": {
+					"id": {
+						"type": "string",
+						"format": "uuid",
+						"description": "Идентификатор кампании"
+					},
+					"master": {
+						"type": "string",
+						"format": "uuid",
+						"description": "Идентификатор мастера кампании"
+					},
 					"name": {
 						"type": "string",
 						"description": "Название кампании"
@@ -741,7 +902,7 @@
 			},
 			"AppResponseWithEventsList": {
 				"type": "object",
-				"description": "Ответ приложения без дополнительной информации",
+				"description": "Ответ приложения со списком событий",
 				"properties": {
 					"status": {
 						"$ref": "#/components/schemas/EScenarioStatus"
@@ -760,7 +921,7 @@
 			},
 			"AppResponseWithEvent": {
 				"type": "object",
-				"description": "Ответ приложения без дополнительной информации",
+				"description": "Ответ приложения с информацией о событии",
 				"required": [
 					"status",
 					"result",
@@ -776,6 +937,96 @@
 					},
 					"payload": {
 						"$ref": "#/components/schemas/Event"
+					}
+				}
+			},
+			"AppResponseWithLocationsList": {
+				"type": "object",
+				"description": "Ответ приложения со списком локаций",
+				"required": [
+					"status",
+					"result",
+					"payload"
+				],
+				"properties": {
+					"status": {
+						"$ref": "#/components/schemas/EScenarioStatus"
+					},
+					"result": {
+						"type": "string",
+						"description": "Текстовое описание результата"
+					},
+					"payload": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/Location"
+						}
+					}
+				}
+			},
+			"AppResponseWithLocation": {
+				"type": "object",
+				"description": "Ответ приложения с информацией о локации",
+				"required": [
+					"status",
+					"result",
+					"payload"
+				],
+				"properties": {
+					"status": {
+						"$ref": "#/components/schemas/EScenarioStatus"
+					},
+					"result": {
+						"type": "string",
+						"description": "Текстовое описание результата"
+					},
+					"payload": {
+						"$ref": "#/components/schemas/Location"
+					}
+				}
+			},
+			"AppResponseWithCompanyList": {
+				"type": "object",
+				"description": "Ответ приложения со списком кампаний",
+				"required": [
+					"status",
+					"result",
+					"payload"
+				],
+				"properties": {
+					"status": {
+						"$ref": "#/components/schemas/EScenarioStatus"
+					},
+					"result": {
+						"type": "string",
+						"description": "Текстовое описание результата"
+					},
+					"payload": {
+						"type": "array",
+						"items": {
+							"$ref": "#/components/schemas/Company"
+						}
+					}
+				}
+			},
+			"AppResponseWithCompany": {
+				"type": "object",
+				"description": "Ответ приложения с информацией о кампании",
+				"required": [
+					"status",
+					"result",
+					"payload"
+				],
+				"properties": {
+					"status": {
+						"$ref": "#/components/schemas/EScenarioStatus"
+					},
+					"result": {
+						"type": "string",
+						"description": "Текстовое описание результата"
+					},
+					"payload": {
+						"$ref": "#/components/schemas/Company"
 					}
 				}
 			}

--- a/server/repository/implementations/postgr/mod.rs
+++ b/server/repository/implementations/postgr/mod.rs
@@ -93,6 +93,14 @@ impl Store for PostgresStore {
 		Ok(may_be_self_info)
 	}
 
+	async fn get_locations_list(&self) -> CoreResult<Vec<Location>> {
+		let locations = sqlx::query_as::<_, Location>("SELECT * FROM locations;")
+			.fetch_all(&self.pool)
+			.await?;
+
+		Ok(locations)
+	}
+
 	async fn get_location_by_id(&self, location_id: Uuid) -> CoreResult<Option<Location>> {
 		let may_be_location = sqlx::query_as::<_, Location>("SELECT * FROM locations WHERE id = $1;")
 			.bind(location_id)
@@ -136,6 +144,15 @@ impl Store for PostgresStore {
 			.await?;
 
 		Ok(may_be_company)
+	}
+
+	async fn get_my_companies(&self, master: Uuid) -> CoreResult<Vec<Company>> {
+		let companies = sqlx::query_as::<_, Company>("SELECT * FROM companies WHERE master = $1;")
+			.bind(master)
+			.fetch_all(&self.pool)
+			.await?;
+
+		Ok(companies)
 	}
 
 	async fn add_company(

--- a/server/repository/mod.rs
+++ b/server/repository/mod.rs
@@ -26,6 +26,7 @@ trait Store {
 	async fn read_profile(&self, user_id: Uuid) -> CoreResult<Option<Profile>>;
 	async fn who_i_am(&self, user_id: Uuid) -> CoreResult<Option<SelfInfo>>;
 
+	async fn get_locations_list(&self) -> CoreResult<Vec<Location>>;
 	async fn get_location_by_id(&self, location_id: Uuid) -> CoreResult<Option<Location>>;
 
 	async fn add_location(
@@ -36,6 +37,8 @@ trait Store {
 	) -> CoreResult<RecordId>;
 
 	async fn get_company_by_id(&self, company_id: Uuid) -> CoreResult<Option<Company>>;
+
+	async fn get_my_companies(&self, master: Uuid) -> CoreResult<Vec<Company>>;
 
 	async fn add_company(
 		&self,
@@ -120,6 +123,10 @@ impl Repository {
 		return self.store.who_i_am(user_id).await;
 	}
 
+	pub(crate) async fn get_locations_list(&self) -> CoreResult<Vec<Location>> {
+		return self.store.get_locations_list().await;
+	}
+
 	pub(crate) async fn get_location_by_id(
 		&self,
 		location_id: Uuid,
@@ -138,6 +145,10 @@ impl Repository {
 
 	pub(crate) async fn get_company_by_id(&self, company_id: Uuid) -> CoreResult<Option<Company>> {
 		return self.store.get_company_by_id(company_id).await;
+	}
+
+	pub(crate) async fn get_my_companies(&self, master: Uuid) -> CoreResult<Vec<Company>> {
+		return self.store.get_my_companies(master).await;
 	}
 
 	pub(crate) async fn add_company(

--- a/server/router.rs
+++ b/server/router.rs
@@ -22,6 +22,9 @@ pub fn create_router(repo: Arc<Repository>) -> Router {
 				.route("/registration", post(H::registration))
 				.route("/signin", post(H::sign_in))
 				.route("/logout", post(H::logout))
+				.route("/locations", get(H::locations::get_locations_list))
+				.route("/locations/{id}", get(H::locations::get_location_by_id))
+				.route("/companies/{id}", get(H::companies::get_company_by_id))
 				.merge(
 					Router::new()
 						.route("/events", get(H::events::read_events_list))
@@ -34,6 +37,7 @@ pub fn create_router(repo: Arc<Repository>) -> Router {
 						.route("/profile", get(H::read_profile))
 						.route("/locations", post(H::locations::add_location))
 						.route("/companies", post(H::companies::add_company))
+						.route("/companies/my", get(H::companies::get_my_companies))
 						.route("/events", post(H::events::add_event))
 						.route("/events/apply/{id}", post(H::events::apply_event))
 						.layer(middleware::from_fn(auth::auth_middleware)),


### PR DESCRIPTION
пока сделал максимально просто, чтобы разблокировать разработку.
в будущем нужно будет добавить фильтр по названию, чтобы можно было начать набирать название и список сокращался.
так же локации надо будет фильтровать по городу, но городов пока нет.

как проверял:
- запустил локальный сервер, зашел на страничку сваггера
- позапрашивал кампании и локации по айдишнику и списком, авторизованным и нет. убедился что поведение ожидаемое